### PR TITLE
Fix textures (and polygons doing that)

### DIFF
--- a/lua/entities/gmod_wire_starfall_screen/cl_init.lua
+++ b/lua/entities/gmod_wire_starfall_screen/cl_init.lua
@@ -152,6 +152,7 @@ function ENT:CodeSent(files, main, owner)
 	function self.renderfunc()
 		if self.instance then
 			data.render.isRendering = true
+			draw.NoTexture()
 			self:runScriptHook("render")
 			data.render.isRendering = nil
 			

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -196,21 +196,30 @@ end
 
 --- Looks up a texture ID by file name.
 -- @param tx Texture file path
-function render_library.getTextureID(tx)
-	local id = surface.GetTextureID(tx)
+function render_library.getTextureID ( tx )
+	local id = surface.GetTextureID( tx )
 	if id then
-		texturecache[id] = tx
+		texturecache[ id ] = { tx }
+		local cacheentry = texturecache[ id ]
+		local mat = Material( tx ) -- Hacky way to get ITexture, if there is a better way - do it!
+		cacheentry[ 2 ] = CreateMaterial( "SF_TEXTURE_" .. id, "UnlitGeneric", {
+			[ "$nolod" ] = 1,
+			[ "$ignorez" ] = 1,
+			[ "$vertexcolor" ] = 1,
+			[ "$vertexalpha" ] = 1
+		} )
+		cacheentry[ 2 ]:SetTexture( "$basetexture", mat:GetTexture( "$basetexture" ) )
 		return id
 	end
 end
 
 --- Sets the texture
-function render_library.setTexture(id)
-	if not SF.instance.data.render.isRendering then error("Not in rendering hook.",2) end
+function render_library.setTexture ( id )
+	if not SF.instance.data.render.isRendering then error( "Not in rendering hook.", 2 ) end
 	if not id then
-		surface.SetTexture(nil)
-	elseif texturecache[id] then
-		surface.SetTexture(id)
+		draw.NoTexture()
+	elseif texturecache[ id ] then
+		surface.SetMaterial( texturecache[ id ][ 2 ] )
 	end
 end
 


### PR DESCRIPTION
Textures had the VertexLitGeneric shader, which did not play nicely with
render targets.
Textures now use UnlitGeneric shader, which basically ignores lighting
and makes textures full-bright.
Also, a texture was set when the render hook got fired, so I added a
draw.NoTexture()

This also fixes polygons, because they were textured and there was no
way to unset the texture. (And setting it would result in the wrong
shader)

setTexture(nil) was throwing errors, I made it use draw.NoTexture() to
reset the current texture.
Fixes #48
