### PR TITLE
Fix screens not triggering read-/writeCell hooks

### DIFF
--- a/lua/entities/gmod_wire_starfall_screen/init.lua
+++ b/lua/entities/gmod_wire_starfall_screen/init.lua
@@ -1,4 +1,3 @@
-
 AddCSLuaFile('cl_init.lua')
 AddCSLuaFile('shared.lua')
 include('shared.lua')
@@ -214,8 +213,16 @@ function ENT:OnRemove()
 	self.instance = nil
 end
 
-function ENT:TriggerInput(key, value)
-	self:runScriptHook("input",key,value)
+function ENT:TriggerInput ( key, value )
+	self:runScriptHook( "input", key, value )
+end
+
+function ENT:ReadCell ( address )
+	return tonumber( self:runScriptHookForResult( "readcell", address ) ) or 0
+end
+
+function ENT:WriteCell ( address, data )
+	self:runScriptHook( "writecell", address, data )
 end
 
 function ENT:BuildDupeInfo()

--- a/lua/entities/gmod_wire_starfall_screen/shared.lua
+++ b/lua/entities/gmod_wire_starfall_screen/shared.lua
@@ -17,3 +17,11 @@ function ENT:runScriptHook(hook, ...)
 		else return rt end
 	end
 end
+
+function ENT:runScriptHookForResult(hook,...)
+	if self.instance and not self.instance.error and self.instance.hooks[hook:lower()] then
+		local ok, rt = self.instance:runScriptHookForResult(hook, ...)
+		if not ok then self:Error(rt)
+		else return rt end
+	end
+end


### PR DESCRIPTION
Your screen needs to have at least one output to test this.
See https://github.com/wiremod/wire/issues/540

Seems to be a problem with the server I was on, should work without outputs
