### PR TITLE
Fix duplicating

### DIFF
--- a/lua/entities/gmod_wire_starfall_processor/init.lua
+++ b/lua/entities/gmod_wire_starfall_processor/init.lua
@@ -133,20 +133,44 @@ end
 function ENT:OnRestore()
 end
 
-function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
-	if self.instance then
-		info.starfall = SF.SerializeCode(self.instance.source, self.instance.mainfile)
+-- A modified copy of garry's table.Copy function
+function tableCopy ( t, lookup_table )
+	if ( t == nil ) then return nil end
+
+	local copy = {}
+	setmetatable( copy, debug.getmetatable( t ) )
+	for i, v in pairs( t ) do
+		if ( not istable( v ) ) then
+			copy[ i ] = v
+		else
+			lookup_table = lookup_table or {}
+			lookup_table[ t ] = copy
+			if lookup_table[ v ] then
+				copy[ i ] = lookup_table[ v ] -- we already copied this table. reuse the copy.
+			else
+				copy[ i ] = table.Copy( v, lookup_table ) -- not yet copied. copy it.
+			end
+		end
 	end
+	return copy
+end
+
+function ENT:BuildDupeInfo ()
+	table.Copy = tableCopy --TODO: Remove once table.Copy is fixed
+	local info = self.BaseClass.BuildDupeInfo( self ) or {}
+	if self.instance then
+		info.starfall = SF.SerializeCode( self.instance.source, self.instance.mainfile )
+	end
+
 	return info
 end
 
-function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+function ENT:ApplyDupeInfo ( ply, ent, info, GetEntByID )
+	self.BaseClass.ApplyDupeInfo( self, ply, ent, info, GetEntByID )
 	self.owner = ply
 	
 	if info.starfall then
-		local code, main = SF.DeserializeCode(info.starfall)
-		self:Compile(code, main)
+		local code, main = SF.DeserializeCode( info.starfall )
+		self:Compile( code, main )
 	end
 end

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -403,7 +403,7 @@ end
 -- ------------------------------------------------------------------------- --
 
 local serialize_replace_regex = "[\"\n]"
-local serialize_replace_tbl = {["\n"] = "£", ['"'] = ""}
+local serialize_replace_tbl = { [ "\n" ] = string.char( 5 ), [ '"' ] = string.char( 4 ) }
 --- Serializes an instance's code in a format compatible with the duplicator library
 -- @param sources The table of filename = source entries. Ususally instance.source
 -- @param mainfile The main filename. Usually instance.mainfile
@@ -416,8 +416,8 @@ function SF.SerializeCode(sources, mainfile)
 	return rt
 end
 
-local deserialize_replace_regex = "[£]"
-local deserialize_replace_tbl = {["£"] = "\n", [''] = '"'}
+local deserialize_replace_regex = "[" .. string.char( 5 ) .. string.char( 4 ) .. "]"
+local deserialize_replace_tbl = { [ string.char( 5 )[ 1 ] ] = "\n", [ string.char( 4 )[ 1 ] ] = '"' }
 --- Deserializes an instance's code.
 -- @return The table of filename = source entries
 -- @return The main filename


### PR DESCRIPTION
Duplicating was not working because table.Copy has a problem with
duplicating tables that have __metatable set to a non-table.
The only way I found to fix this is by replacing table.Copy altogether,
because adv. duplicator is using table.Copy and the original entity
cannot be modified for security reasons. I made a PR to garry to fix his
table.Copy, once that is accepted, that part can be removed.

In addition, screens were using outdated fields.
Fixes #56
