### PR TITLE
sf_defaultquota now shared properly. instance.context.ops now a function...

### DIFF
--- a/lua/entities/gmod_wire_starfall_processor/init.lua
+++ b/lua/entities/gmod_wire_starfall_processor/init.lua
@@ -87,7 +87,7 @@ function ENT:Think()
 	self.BaseClass.Think(self)
 	
 	if self.instance and not self.instance.error then
-		self:UpdateState(tostring(self.instance.ops).." ops, "..tostring(math.floor(self.instance.ops / self.instance.context.ops * 100)).."%")
+		self:UpdateState( tostring( self.instance.ops ) .. " ops, " .. tostring( math.floor( self.instance.ops / self.instance.context.ops() * 100 ) ) .. "%" )
 
 		self.instance:resetOps()
 		self:RunScriptHook("think")

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -36,7 +36,7 @@ end
 -- @return True if ok
 -- @return A table of values that the hook returned
 function SF.Instance:runWithOps(func,...)
-	local maxops = self.context.ops
+	local maxops = self.context.ops()
 	
 	local function ophook(event)
 		self.ops = self.ops + 500

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -108,7 +108,7 @@ end
 
 --- Gets the ops hard quota
 function SF.DefaultEnvironment.opsMax()
-	return SF.instance.context.ops
+	return SF.instance.context.ops()
 end
 
 -- The below modules have the Gmod functions removed (the ones that begin with a capital letter),
@@ -288,7 +288,7 @@ function SF.DefaultEnvironment.pcall ( ... )
     ok, err = pcall( ... )
 
     -- don't catch quota errors
-    if SF.instance.ops > SF.instance.context.ops then
+    if SF.instance.ops > SF.instance.context.ops() then
         error( err, 0 )
     end
 

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -131,14 +131,14 @@ end
 -- @param env The environment metatable to use for the script. Default is SF.DefaultEnvironmentMT
 -- @param directives Additional Preprocessor directives to use. Default is an empty table
 -- @param permissions The permissions manager to use. Default is SF.DefaultPermissions
--- @param ops Operations quota. Default is specified by the convar "sf_defaultquota"
+-- @param ops Operations quota function. Default is specified by the convar "sf_defaultquota" and returned when calling ops()
 -- @param libs Additional (local) libraries for the script to access. Default is an empty table.
 function SF.CreateContext(env, directives, permissions, ops, libs)
 	local context = {}
 	context.env = env or SF.DefaultEnvironmentMT
 	context.directives = directives or {}
 	context.permissions = permissions or SF.Permissions
-	context.ops = ops or SF.defaultquota:GetInt()
+	context.ops = ops or function () return SF.defaultquota:GetInt() end
 	context.libs = libs or {}
 	return context
 end


### PR DESCRIPTION
... returning ops quota. Replaces old context.ops reference to call as function.

Fixes #17
