### PR TITLE
Fix players only being able to spawn one screen

### DIFF
--- a/lua/entities/starfall_screen/init.lua
+++ b/lua/entities/starfall_screen/init.lua
@@ -127,7 +127,6 @@ function ENT:CodeSent(ply, files, mainfile)
 		
 		if not self.instance then return end
 		
-		self:UpdateName("")
 		local r,g,b,a = self:GetColor()
 		self:SetColor(Color(255, 255, 255, a))
 		self.sharedscreen = true


### PR DESCRIPTION
Not exactly sure why it didn't happen for all the people, but at least for me it ended up happening constantly.
The screen is calling "UpdateName" in CodeSent, which is nil. Since screens don't even have a visible name, just removing this should be fine.
