### PR TITLE
Add crude usage examples to directives

### DIFF
--- a/docgen/tagletsf.lua
+++ b/docgen/tagletsf.lua
@@ -219,7 +219,7 @@ local function parse_comment ( block, first_line, libs, classes )
 	table.foreachi(block.comment, function (_, line)
 		line = util.trim_comment(line)
 		
-		local r, _, tag, text = string.find(line, "@([_%w%.]+)%s*(.*)")
+		local r, _, tag, text = string.find( line, "^@([_%w%.]+)%s*(.*)" )
 		if r ~= nil then
 			-- found new tag, add previous one, and start a new one
 			-- TODO: what to do with invalid tags? issue an error? or log a warning?
@@ -228,6 +228,7 @@ local function parse_comment ( block, first_line, libs, classes )
 			currenttag = tag
 			currenttext = text
 		else
+			line = line:gsub( "^\\", "" )
 			currenttext = util.concat( currenttext, "\n" .. line )
 			assert(string.sub(currenttext, 1, 1) ~= " ", string.format("`%s', `%s'", currenttext, line))
 		end

--- a/lua/starfall/preprocessor.lua
+++ b/lua/starfall/preprocessor.lua
@@ -155,14 +155,31 @@ SF.Preprocessor.SetGlobalDirective("sharedscreen",directive_sharedscreen)
 -- @name include
 -- @class directive
 -- @param path Path to the file
+-- @usage
+-- \--@include lib/someLibrary.txt
+-- 
+-- require( "lib/someLibrary.txt" )
+-- -- CODE
 
 --- Set the name of the script.
 -- This will become the name of the tab and will show on the overlay of the processor
 -- @name name
 -- @class directive
 -- @param name Name of the script
+-- @usage
+-- \--@name Awesome script
+-- -- CODE
 
 --- For screens, make the script run on the server, as well.
 -- You can use "if SERVER" and "if CLIENT" to determine if the script is currently being run on the server or the client, respectively.
 -- @name sharedscreen
 -- @class directive
+--@usage
+-- \--@sharedscreen
+--
+-- if SERVER then
+-- \	-- Do important calculations
+-- \	-- Send net message
+-- else
+-- \	-- Display result of important calculations
+-- end


### PR DESCRIPTION
The usage example might actually be helpful, but the main point is the ability to have "--@" in the usage, which was previously impossible.
