### PR TITLE
Fix hologram scaling

### DIFF
--- a/lua/entities/starfall_hologram/init.lua
+++ b/lua/entities/starfall_hologram/init.lua
@@ -12,12 +12,12 @@ function ENT:Initialize()
 	self:DrawShadow( false )
 end
 
-function ENT:SetScale(scale)
-	net.Start("starfall_hologram_scale")
-		net.WriteEntity(self)
-		net.WriteDouble(scale.x)
-		net.WriteDouble(scale.y)
-		net.WriteDouble(scale.z)
+function ENT:SetScale ( scale )
+	net.Start( "starfall_hologram_scale" )
+		net.WriteUInt( self:EntIndex(), 32 )
+		net.WriteDouble( scale.x )
+		net.WriteDouble( scale.y )
+		net.WriteDouble( scale.z )
 	net.Broadcast()
 end
 


### PR DESCRIPTION
net.WriteEntity used to send a 32 bit unsigned integer, which is
expected on the client side.
Garry seems to have changed that. Sending the entIndex as 32-bit
unsigned integer should work properly.
