### PR TITLE
Fixed VMatrix:scaleTranslation

### DIFF
--- a/lua/starfall/libs_sh/vmatrix.lua
+++ b/lua/starfall/libs_sh/vmatrix.lua
@@ -58,7 +58,7 @@ end
 --- Scales the absolute translation
 -- @param num Amount to scale by
 function vmatrix_methods:scaleTranslation ( num )
-	SF.CheckType( num, "Number" )
+	SF.CheckType( num, "number" )
 
 	local v = unwrap( self )
 	v:ScaleTranslation( num )


### PR DESCRIPTION
Accidentally used uppercase N on type check.
Also, I'm an idiot for missing this on previous commit.
