### PR TITLE
Fix hook race condition

### DIFF
--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -134,17 +134,21 @@ end)
 local wrapArguments = SF.Sanitize
 
 local function run( hookname, customfunc, ... )
+	local result = {}
 	for instance,_ in pairs( registered_instances ) do
 		local ret = { instance:runScriptHookForResult( hookname, wrapArguments( ... ) ) }
 		
 		local ok = table.remove( ret, 1 )
 		if ok then
-			if not customfunc then return end
-			return customfunc( instance, ret, ... )
+			if customfunc then
+				local sane = customfunc( instance, ret, ... )
+				result = sane ~= nil and { sane } or result
+			end
 		else
 			instance:Error( "Hook '" .. hookname .. "' errored with " .. ret[1], ret[2] )
 		end
 	end
+	return unpack( result )
 end
 
 


### PR DESCRIPTION
Previously, if two or more hooks were listening for the same event, only
one would fire, unless it was a starfall internal hook like render or
think.

A race condition still exists, if two or more hooks return a different
value, but I don't think anything can be done about that.
