### PR TITLE
Remove table.Copy hack

### DIFF
--- a/lua/entities/base_starfall_entity/init.lua
+++ b/lua/entities/base_starfall_entity/init.lua
@@ -9,27 +9,6 @@ function ENT:Initialize ()
 	self:SetMoveType( MOVETYPE_VPHYSICS )
 	self:SetSolid( SOLID_VPHYSICS )
 	self.instance = nil
-
-	self.tableCopy = function ( t, lookup_table )
-		if ( t == nil ) then return nil end
-
-		local copy = {}
-		setmetatable( copy, debug.getmetatable( t ) )
-		for i, v in pairs( t ) do
-			if ( not istable( v ) ) then
-				copy[ i ] = v
-			else
-				lookup_table = lookup_table or {}
-				lookup_table[ t ] = copy
-				if lookup_table[ v ] then
-					copy[ i ] = lookup_table[ v ] -- we already copied this table. reuse the copy.
-				else
-					copy[ i ] = table.Copy( v, lookup_table ) -- not yet copied. copy it.
-				end
-			end
-		end
-		return copy
-	end
 end
 
 function ENT:OnRemove ()
@@ -43,8 +22,6 @@ function ENT:onRestore ()
 end
 
 function ENT:BuildDupeInfo ()
-	-- Remove table.Copy fix when Garrysmod updates with @Xandaros patch.
-	table.Copy = self.tableCopy
 	return {}
 end
 


### PR DESCRIPTION
This used to be necessary because the table.Copy function had a bug,
which has since been fixed upstream.

Fix #185
