### PR TITLE
Fixed multiline coloring and missing examples folder from the file browser.

### DIFF
--- a/lua/autorun/client/examples.lua
+++ b/lua/autorun/client/examples.lua
@@ -1,0 +1,21 @@
+-- copies examples folder from addon to data folder
+
+local function moveFolder( path )
+	file.CreateDir( path )
+	local files, directories = file.Find( "data/" .. path .. "*", "GAME" )
+	for _, name in pairs( files ) do
+		file.Write( path .. name, file.Read( "data/" .. path .. name, "GAME" ))
+	end
+	for _, name in pairs( directories ) do
+		moveFolder( path .. name .. "/" )
+	end
+end
+
+
+if not ConVarExists( "sf_examples_copied" ) and file.IsDir( "data/starfall/examples", "GAME" ) and not file.IsDir( "starfall/examples", "DATA" ) then
+	CreateClientConVar( "sf_examples_copied", 1, true, false ) -- Creates Convar to prevent repeated copying
+	if not file.IsDir( "starfall", "DATA" ) then
+		file.CreateDir( "starfall" )
+	end
+	moveFolder( "starfall/examples/" )
+end

--- a/lua/autorun/server/sf_init.lua
+++ b/lua/autorun/server/sf_init.lua
@@ -1,4 +1,5 @@
 AddCSLuaFile( "autorun/client/sf_models.lua" )
+AddCSLuaFile( "autorun/client/examples.lua" )
 
 resource.AddFile( "materials/models/spacecode/glass.vmt" )
 resource.AddFile( "materials/models/spacecode/sfchip.vmt" )


### PR DESCRIPTION
Fixed editor not coloring Lua 5.1 multiline comments and strings syntax: [=[string]=]
Fixed editor not coloring break keyword.
Examples folder is moved to data folder on first launch, so the user can access it from the editor.
