### PR TITLE
Documentation parameter fixes for multiple functions

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -58,7 +58,7 @@ SF.DefaultEnvironment.pairs = pairs
 -- @name SF.DefaultEnvironment.type
 -- @class function
 -- @param obj Object to get type of
--- @return 
+-- @return The name of the object's type.
 SF.DefaultEnvironment.type = function( obj )
 	local tp = getmetatable( obj )
 	return type(tp) == "string" and tp or type( obj )

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -59,9 +59,9 @@ SF.DefaultEnvironment.pairs = pairs
 -- @class function
 -- @param obj Object to get type of
 -- @return 
-SF.DefaultEnvironment.type = function( val )
-	local tp = getmetatable( val )
-	return type(tp) == "string" and tp or type( val )
+SF.DefaultEnvironment.type = function( obj )
+	local tp = getmetatable( obj )
+	return type(tp) == "string" and tp or type( obj )
 end
 --- Same as Lua's next
 -- @name SF.DefaultEnvironment.next

--- a/lua/starfall/libs_sv/holograms.lua
+++ b/lua/starfall/libs_sv/holograms.lua
@@ -234,7 +234,7 @@ end
 --- Suppress Engine Lighting of a hologram. Disabled by default.
 -- @server
 -- @class function
--- @param enable Boolean to represent if shading should be set or not.
+-- @param suppress Boolean to represent if shading should be set or not.
 function hologram_methods:suppressEngineLighting ( suppress )
     SF.CheckType( suppress, "boolean" )
 


### PR DESCRIPTION
Fixed parameter so that it displays properly in documentation

From docs:
`SF.DefaultEnvironment.type (val, obj)` <-- should only be one argument
also:
`hologram_methods:suppressEngineLighting (suppress, enable)`
