### PR TITLE
Upload/Download Functionality

### DIFF
--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -28,7 +28,9 @@ function ENT:Compile ( codetbl, mainfile )
 	instance.runOnError = function ( inst, ... ) self:Error( ... ) end
 	
 	self.instance = instance
-	
+	self.mainfile = instance.mainfile
+	self.source = instance.source
+
 	local ok, msg, traceback = instance:initialize ()
 	if not ok then
 		self:Error( msg, traceback )

--- a/lua/entities/starfall_screen/init.lua
+++ b/lua/entities/starfall_screen/init.lua
@@ -83,7 +83,8 @@ function ENT:Error ( msg, traceback )
 end
 
 function ENT:CodeSent(ply, files, mainfile)
-	if ply ~= self.owner then return end
+	if ( CPPI and not self:CPPICanTool( ply, "starfall_screen" ) ) or 
+			( not CPPI and ply ~= self.owner  ) then return end
 	local update = self.mainfile ~= nil
 
 	self.files = files

--- a/lua/starfall/editor.lua
+++ b/lua/starfall/editor.lua
@@ -16,6 +16,17 @@ SF.Editor = {}
 
 if CLIENT then
 
+	local invalid_filename_chars = {
+		["*"] = "",
+		["?"] = "",
+		[">"] = "",
+		["<"] = "",
+		["|"] = "",
+		["\\"] = "",
+		['"'] = "",
+		[" "] = "_",
+	}
+
 	local keywords = {
 		["if"] = true,
 		["elseif"] = true,
@@ -304,6 +315,58 @@ if CLIENT then
 			end
 		end
 
+		function SF.Editor.editor:SaveFile( Line, close, SaveAs )
+			self:ExtractName( )
+			if close and self.chip then
+				if not self:Validate( true ) then return end
+				net.Start( "starfall_uploadandexit" )
+					net.WriteEntity( self.chip ) 
+				net.SendToServer( )
+				self:Close( )
+				return
+			end
+			if not Line or SaveAs or Line == self.Location .. "/" .. ".txt" then
+				local str
+				if self.C[ 'Browser' ].panel.File then
+					str = self.C[ 'Browser' ].panel.File.FileDir -- Get FileDir
+					if str and str ~= "" then -- Check if not nil
+						-- Remove "expression2/" or "cpuchip/" etc
+						local n, _ = str:find( "/", 1, true )
+						str = str:sub( n + 1, -1 )
+
+						if str and str ~= "" then -- Check if not nil
+							if str:Right( 4 ) == ".txt" then -- If it's a file
+								str = string.GetPathFromFilename( str ):Left( -2 ) -- Get the file path instead
+								if not str or str == "" then
+									str = nil
+								end
+							end
+						else
+							str = nil
+						end
+					else
+						str = nil
+					end
+				end
+				Derma_StringRequestNoBlur( "Save to New File", "", ( str ~= nil and str .. "/" or "" ) .. self.savefilefn,
+					function( strTextOut )
+						strTextOut = string.gsub( strTextOut, ".", invalid_filename_chars )
+						self:SaveFile( self.Location .. "/" .. strTextOut .. ".txt", close )
+					end )
+				return
+			end
+
+			file.Write( Line, self:GetCode( ) )
+
+			local panel = self.C[ 'Val' ].panel
+			timer.Simple( 0, function( ) panel.SetText( panel, "   Saved as " .. Line ) end )
+
+			if not self.chip then self:ChosenFile( Line ) end
+			if close then
+				SF.AddNotify( LocalPlayer(), "Starfall code saved as " .. Line .. ".", NOTIFY_GENERIC, 7, NOTIFYSOUND_DRIP3 )
+				self:Close( )
+			end
+		end
 
 		SF.Editor.editor:Setup("SF Editor", "starfall", "nothing") -- Setting the editor type to not nil keeps the validator line
 		
@@ -377,6 +440,7 @@ if CLIENT then
 				self.C['Val'].panel:SetFGColor(255, 255, 255, 128)
 				self.C['Val'].panel:SetText( "   No Syntax Errors" )
 			end
+			return true
 		end
 	end
 	
@@ -460,6 +524,21 @@ if CLIENT then
 		end
 	end
 
+	net.Receive( "starfall_download", function( len )
+		local ent = net.ReadEntity()
+		SF.Editor.editor.chip = ent
+		local mainfile = net.ReadTable()[1]
+		local files = net.ReadTable()
+		local editor = SF.Editor.editor
+		for i = 1, editor:GetNumTabs( ) do
+			table.GetFirstValue( files )
+			if editor:GetEditor( i ):GetValue( ) == files[ mainfile ] then
+				editor:SetActiveTab( i )
+				return
+			end
+		end
+		editor:Open( mainfile, files[ mainfile ], true )
+	end )
 
 	-- CLIENT ANIMATION
 
@@ -510,6 +589,8 @@ else
 	-- this might fit better elsewhere
 
 	util.AddNetworkString("starfall_editor_status")
+	util.AddNetworkString("starfall_uploadandexit")
+	util.AddNetworkString("starfall_download")
 
 	resource.AddFile( "materials/radon/starfall2.png" )
 	resource.AddFile( "materials/radon/starfall2.vmt" )
@@ -542,5 +623,28 @@ else
 		net.WriteBit(false)
 		net.Broadcast()
 	end
+
+	net.Receive( "starfall_uploadandexit", function( len, ply ) 
+		ent = net.ReadEntity()
+			
+		--Check cppi or ownership again incase someone manually changes SF.Editor.editor.chip or permissions change
+		if ( CPPI and not ent:CPPICanTool( ply, ent:GetClass() ) ) or ( not CPPI and ply ~= ent.owner ) then 
+			SF.AddNotify( ply, "Cannot upload SF code, permission denied", NOTIFY_ERROR, 7, NOTIFYSOUND_ERROR1 )
+			return 
+		end
+
+		if not SF.RequestCode( ply, function( mainfile, files )
+			if not mainfile then return end
+			if not IsValid( ent ) then return end
+
+			if ent:GetClass() == "starfall_processor" then
+				ent:Compile( files, mainfile )
+			else
+				ent:CodeSent( ply, files, mainfile )
+			end
+		end ) then
+			SF.AddNotify( ply, "Cannot upload SF code, please wait for the current upload to finish.", NOTIFY_ERROR, 7, NOTIFYSOUND_ERROR1 )
+		end
+	end )
 
 end

--- a/lua/starfall/editor.lua
+++ b/lua/starfall/editor.lua
@@ -486,6 +486,8 @@ if CLIENT then
 		local loaded = {}
 		local ppdata = {}
 
+		local currentIncludes = SF.Editor.editor:GetCurrentEditor().includes
+
 		local function recursiveLoad(path)
 			if loaded[path] then return end
 			loaded[path] = true
@@ -493,6 +495,8 @@ if CLIENT then
 			local code
 			if path == codename and maincode then
 				code = maincode
+			elseif currentIncludes and currentIncludes[path] then
+				code = currentIncludes[path]
 			else
 				code = file.Read("Starfall/"..path, "DATA") or error("Bad include: "..path,0)
 			end
@@ -530,6 +534,9 @@ if CLIENT then
 		local mainfile = net.ReadTable()[1]
 		local files = net.ReadTable()
 		local editor = SF.Editor.editor
+
+		editor:GetCurrentEditor().includes = files
+
 		for i = 1, editor:GetNumTabs( ) do
 			table.GetFirstValue( files )
 			if editor:GetEditor( i ):GetValue( ) == files[ mainfile ] then

--- a/lua/weapons/gmod_tool/stools/starfall_screen.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_screen.lua
@@ -87,11 +87,13 @@ function TOOL:LeftClick( trace )
 
 	if trace.Entity:IsValid() and trace.Entity:GetClass() == "starfall_screen" then
 		local ent = trace.Entity
-		if not SF.RequestCode(ply, function(mainfile, files)
+		if ( CPPI and not ent:CPPICanTool( self:GetOwner(), "starfall_screen" ) ) or 
+			( not CPPI and self:GetOwner() ~= ent.owner  ) then return end
+		if not SF.RequestCode( ply, function( mainfile, files )
 			if not mainfile then return end
-			if not IsValid(ent) then return end
-			ent:CodeSent(ply, files, mainfile)
-		end) then
+			if not IsValid( ent ) then return end
+			ent:CodeSent( ply, files, mainfile )
+		end ) then
 			SF.AddNotify( ply, "Cannot upload SF code, please wait for the current upload to finish.", NOTIFY_ERROR, 7, NOTIFYSOUND_ERROR1 )
 		end
 		return true
@@ -120,11 +122,11 @@ function TOOL:LeftClick( trace )
 
 	ply:AddCleanup( "starfall_screen", sf )
 	
-	if not SF.RequestCode(ply, function(mainfile, files)
+	if not SF.RequestCode( ply, function( mainfile, files )
 		if not mainfile then return end
-		if not IsValid(sf) then return end
-		sf:CodeSent(ply, files, mainfile)
-	end) then
+		if not IsValid( sf ) then return end
+		sf:CodeSent( ply, files, mainfile )
+	end ) then
 		SF.AddNotify( ply, "Cannot upload SF code, please wait for the current upload to finish.", NOTIFY_ERROR, 7, NOTIFYSOUND_ERROR1 )
 	end
 
@@ -132,7 +134,22 @@ function TOOL:LeftClick( trace )
 end
 
 function TOOL:RightClick( trace )
-	if SERVER then self:GetOwner():SendLua("SF.Editor.open()") end
+	if SERVER then 
+		self:GetOwner():SendLua("SF.Editor.open()") 
+		if trace.Entity:IsValid() and trace.Entity:GetClass() == "starfall_screen" then
+			local ent = trace.Entity
+			if ( CPPI and not ent:CPPICanTool( self:GetOwner(), "starfall_screen" ) ) or 
+				( not CPPI and self:GetOwner() ~= ent.owner  ) then return end
+
+			if not ent.files then return end
+			
+			net.Start( "starfall_download" )
+				net.WriteEntity( ent )
+				net.WriteTable( { ent.mainfile } )
+				net.WriteTable( ent.files )
+			net.Send( self:GetOwner() )
+		end
+	end
 	return false
 end
 


### PR DESCRIPTION
Added download functionality
Added uploading to a processor/screen
Added prop protection to downloading and placing/uploading to a processor/screen

Notes: 
I had to store the mainfile and source code in the processor entity
I had to set the editor save file function to work with Upload and Exit
I added prop protection when left clicking on an already spawned processor/screen
The prop protection works with CPPI, if there is no CPPI then uploading and downloading still works for the owner of the entity
