### PR TITLE
Fixed Color object's metatable setting rawvalue on newindex.

### DIFF
--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -24,8 +24,24 @@ SF.DefaultEnvironment.Color = function ( ... )
 end
 
 --- __newindex metamethod
-function color_metatable.__newindex ( t, k, v )
-	rawset( t, k, v )
+function color_metatable.__newindex ( wrapped_table, key, value )
+	SF.CheckType( value, "number" )
+
+    if math.floor( value ) ~= value then 
+        error( "value must be an integer" ) 
+    end
+    if value > 255 or value < 1 then 
+        error( "value must be between 1 and 255" ); 
+    end
+    
+    if not ( key == 'r' or key == 'g' or key == 'b' or key == 'a' ) then
+        error( "key must be r, g, b, or a" );
+    end
+
+    local unwrapped_table = unwrap( wrapped_table )
+    
+
+    unwrapped_table[key] = value
 end
 
 local _p = color_metatable.__index


### PR DESCRIPTION
It now sets the corresponding value on the unwrapped color object.  Also
added validation to only allow users to set valid keys on the Color
object.

NOTE I have not had a chance to test this.  I will if I get GMOD running tonight.

Should fix #282 
