### PR TITLE
Created a provider to check for usergroups

### DIFF
--- a/lua/starfall/permissions/database.lua
+++ b/lua/starfall/permissions/database.lua
@@ -1,0 +1,11 @@
+if SERVER then
+    local P = SF.Permissions
+
+    P.useMysqloo = false
+    P.host = "127.0.0.1"
+    P.port = 3306
+    P.user = "starfall"
+    P.pass = "password"
+    P.dbName = "starfall"
+    P.table = "sf_permissions"
+end

--- a/lua/starfall/permissions/providers_cl/group.lua
+++ b/lua/starfall/permissions/providers_cl/group.lua
@@ -8,12 +8,20 @@ local ALLOW = SF.Permissions.Result.ALLOW
 local DENY = SF.Permissions.Result.DENY
 local NEUTRAL = SF.Permissions.Result.NEUTRAL
 
+local function getGroup( ply )
+	if evolve then
+		return ply:EV_GetRank( )
+	else
+		return ply:GetUserGroup( )
+	end
+end
+
 function Provider:check ( principal, target, key )
 	if principal == LocalPlayer() then
-		if SF.Permissions.privileges[ key ].group[ principal:GetUserGroup( ) ] or SF.Permissions.privileges[ key ].group[ "*" ] then
+		if SF.Permissions.privileges[ key ].group[ getGroup( principal ) ] or SF.Permissions.privileges[ key ].group[ "*" ] then
 			return ALLOW
 		end
-	elseif SF.Permissions.privileges[ key .. ".others" ].group[ principal:GetUserGroup( ) ] or SF.Permissions.privileges[ key .. ".others" ].group[ "*" ] then
+	elseif SF.Permissions.privileges[ key .. ".others" ].group[ getGroup( principal ) ] or SF.Permissions.privileges[ key .. ".others" ].group[ "*" ] then
 		return ALLOW
 	end
 

--- a/lua/starfall/permissions/providers_cl/group.lua
+++ b/lua/starfall/permissions/providers_cl/group.lua
@@ -1,0 +1,24 @@
+---------------------------------------------------------------------
+-- SF Client Group Provider
+---------------------------------------------------------------------
+
+local Provider = setmetatable( {}, { __index = SF.Permissions.Provider } )
+
+local ALLOW = SF.Permissions.Result.ALLOW
+local DENY = SF.Permissions.Result.DENY
+local NEUTRAL = SF.Permissions.Result.NEUTRAL
+
+function Provider:check ( principal, target, key )
+	if principal == LocalPlayer() then
+		if SF.Permissions.privileges[ key ].group[ principal:GetUserGroup( ) ] or SF.Permissions.privileges[ key ].group[ "*" ] then
+			return ALLOW
+		end
+	elseif SF.Permissions.privileges[ key .. ".others" ].group[ principal:GetUserGroup( ) ] or SF.Permissions.privileges[ key .. ".others" ].group[ "*" ] then
+		return ALLOW
+	end
+
+	SF.throw( "You do not have permission to run ".. SF.Permissions.privileges[ key ].name ..".", 2 )
+	return DENY
+end
+
+SF.Permissions.registerProvider( Provider )

--- a/lua/starfall/permissions/providers_sh/group.lua
+++ b/lua/starfall/permissions/providers_sh/group.lua
@@ -29,10 +29,6 @@ if SERVER then
 				P.privileges[ id ].group[ query[ i ].group ] = true
 			end
 		end
-		net.Start( "sf_groupperm_response" )
-			net.WriteString( id )
-			net.WriteTable( P.privileges[ id ] )
-		net.Broadcast()
 	end
 
 	util.AddNetworkString( "sf_sendperm_group" )
@@ -55,6 +51,10 @@ end
 hook.Add( "sf_registerPrivilege", "SF_PERM", function( id, name, description, source )
 	if SERVER then
 		registerGroup( id, "superadmin" )
+		net.Start( "sf_groupperm_response" )
+			net.WriteString( id )
+			net.WriteTable( P.privileges[ id ] )
+		net.Broadcast()
 	elseif CLIENT then
 		if source == "cl" then
 			table.insert( permRequests, { id = id, name = name, desc = description, group = "*" } )
@@ -170,11 +170,19 @@ elseif CLIENT then
 	end )
 end
 
+local function getGroup( ply )
+	if evolve then
+		return ply:EV_GetRank( )
+	else
+		return ply:GetUserGroup( )
+	end
+end
+
 --- Prints the permission passed
 P.registerPrivilege( "permissions.get", "sf_getperm", "Console command to get the required group(s) of a starfall permission" )
 concommand.Add( "sf_getperm", function( ply, _, args )
 	if CLIENT then
-		if not P.privileges[ "permissions.get" ].group[ ply:GetUserGroup() ] then return end
+		if not P.privileges[ "permissions.get" ].group[ getGroup( ply ) ] then return end
 	end
 
 	if P.privileges[ args[1] ] ~= nil then
@@ -207,7 +215,7 @@ end )
 P.registerPrivilege( "permissions.add", "sf_addperm", "Console command to grant access to a starfall permission to a usergroup" )
 concommand.Add( "sf_addperm", function( ply, _, args )
 	if CLIENT then
-		if not P.privileges[ "permissions.add" ].group[ ply:GetUserGroup() ] then return end
+		if not P.privileges[ "permissions.add" ].group[ getGroup( ply ) ] then return end
 	end
 
 	if not P.groups[ args[ 2 ] ] and args[ 2 ] ~= "*" then
@@ -243,7 +251,7 @@ end )
 P.registerPrivilege( "permissions.delete", "sf_delperm", "Console command to revoke access to a starfall permission from a usergroup" )
 concommand.Add( "sf_delperm", function( ply, _, args )
 	if CLIENT then
-		if not P.privileges[ "permissions.delete" ].group[ ply:GetUserGroup() ] then return end
+		if not P.privileges[ "permissions.delete" ].group[ getGroup( ply ) ] then return end
 	end
 
 	if not P.groups[ args[ 2 ] ] and args[ 2 ] ~= "*" then

--- a/lua/starfall/permissions/providers_sh/group.lua
+++ b/lua/starfall/permissions/providers_sh/group.lua
@@ -1,0 +1,273 @@
+---------------------------------------------------------------------
+-- SF Group Functions
+---------------------------------------------------------------------
+
+local P = SF.Permissions
+
+if SERVER then
+	--- Registers a group privilege to the SF.Permissions.privileges table
+	function registerGroup( id, group )
+		SF.Permissions.privileges[ id ].group = {}
+
+		local queryString = {
+			insert = "INSERT INTO ".. P.table .." (`permission`, `group`) SELECT '".. id .."', '".. group .."' WHERE NOT EXISTS (SELECT * FROM ".. P.table .." WHERE `group`='".. id .."' AND `permission`='".. group .."');",
+			select = "SELECT `group` FROM sf_permissions WHERE permission='".. id .."'"
+		}
+		if P.useMysqloo and P.database then
+			local query = P.database:query( queryString.insert )
+			query:start()
+			local query = P.database:query( queryString.select )
+			query:start()
+			query:wait()
+			for i = 1, #( query ) do
+				P.privileges[ id ].group[ query[ i ].group ] = true
+			end
+		else
+			local query = sql.Query( queryString.insert )
+			local query = sql.Query( queryString.select )
+			for i = 1, #( query ) do
+				P.privileges[ id ].group[ query[ i ].group ] = true
+			end
+		end
+		net.Start( "sf_groupperm_response" )
+			net.WriteString( id )
+			net.WriteTable( P.privileges[ id ] )
+		net.Broadcast()
+	end
+
+	util.AddNetworkString( "sf_sendperm_group" )
+	net.Receive( "sf_sendperm_group", function( _, ply )
+		local id = net.ReadString()
+		local name = net.ReadString()
+		local desc = net.ReadString()
+		local group = net.ReadString()
+		P.registerPrivilege( id, name, desc )
+		registerGroup( id, group )
+		net.Start( "sf_groupperm_response" )
+			net.WriteString( id )
+			net.WriteTable( P.privileges[ id ] )
+		net.Broadcast()
+	end )
+elseif CLIENT then
+	permRequests = {}
+end
+
+hook.Add( "sf_registerPrivilege", "SF_PERM", function( id, name, description, source )
+	if SERVER then
+		registerGroup( id, "superadmin" )
+	elseif CLIENT then
+		if source == "cl" then
+			table.insert( permRequests, { id = id, name = name, desc = description, group = "*" } )
+			table.insert( permRequests, { id = id .. ".others", name = name .. " (Others)", desc = description, group = "superadmin" } )
+		end
+	end
+end )
+
+if SERVER then
+	util.AddNetworkString( "sf_clperm_request" )
+	util.AddNetworkString( "sf_groupperm_response" )
+	hook.Add( "PlayerInitialSpawn", "sf_sendperm_group", function( ply )
+		net.Start( "sf_clperm_request" )
+		net.Send( ply )
+	end )
+elseif CLIENT then
+	net.Receive( "sf_clperm_request", function( )
+		for _, v in pairs( permRequests ) do
+			net.Start( "sf_sendperm_group" )
+				net.WriteString( v.id )
+				net.WriteString( v.name)
+				net.WriteString( v.desc )
+				net.WriteString( v.group )
+			net.SendToServer()
+		end
+	end )
+
+	net.Receive( "sf_groupperm_response", function( )
+		local id = net.ReadString()
+		local priv = net.ReadTable()
+		P.privileges[ id ] = priv
+	end )
+end
+
+if SERVER then
+	util.AddNetworkString( "sf_concommand_perm_get" )
+	util.AddNetworkString( "sf_concommand_perm_add" )
+	util.AddNetworkString( "sf_concommand_perm_del" )
+	net.Receive( "sf_concommand_perm_add", function( )
+		local id = net.ReadString()
+		local group = net.ReadString()
+
+		local perm = P.privileges[ id ]
+		perm.group[ group ] = true
+
+		local queryString = {
+			insert = "INSERT INTO ".. P.table .." (`permission`, `group`) SELECT '".. id .."', '".. group .."' WHERE NOT EXISTS (SELECT * FROM ".. P.table .." WHERE `group`='".. id .."' AND `permission`='".. group .."');",
+			select = "SELECT `group` FROM sf_permissions WHERE permission='".. id .."'"
+		}
+
+		if P.useMysqloo and P.database then
+			local query = P.database:query( queryString.insert )
+			query:start()
+			local query = P.database:query( queryString.select )
+			query:start()
+			query:wait()
+			for i = 1, #( query ) do
+				P.privileges[ id ].group[ query[ i ].group ] = true
+			end
+		else
+			local query = sql.Query( queryString.insert )
+			local query = sql.Query( queryString.select )
+			for i = 1, #( query ) do
+				P.privileges[ id ].group[ query[ i ].group ] = true
+			end
+		end
+		net.Start( "sf_groupperm_response" )
+			net.WriteString( id )
+			net.WriteTable( P.privileges[ id ] )
+		net.Broadcast()
+	end )
+
+	net.Receive( "sf_concommand_perm_del", function( )
+		 local id = net.ReadString()
+		local group = net.ReadString()
+
+		local perm = P.privileges[ id ]
+		perm.group[ group ] = nil
+
+		local queryString = {
+			delete = "DELETE FROM ".. P.table .." WHERE `permission`='".. args[ 1 ] .."' AND `group`='".. args[ 2 ] .."';",
+			select = "SELECT `group` FROM sf_permissions WHERE permission='".. id .."'"
+		}
+
+		 if P.useMysqloo and P.database then
+			 local query = P.database:query( queryString.delete )
+			 query:start()
+			 local query = P.database:query( queryString.select )
+			 query:start()
+			 query:wait()
+			 for i = 1, #( query ) do
+				 P.privileges[ id ].group[ query[ i ].group ] = true
+			 end
+		 else
+			 local query = sql.Query( queryString.delete )
+			 local query = sql.Query( queryString.select )
+			 for i = 1, #( query ) do
+				 P.privileges[ id ].group[ query[ i ].group ] = true
+			 end
+		 end
+		 net.Start( "sf_groupperm_response" )
+			 net.WriteString( id )
+			 net.WriteTable( P.privileges[ id ] )
+		 net.Broadcast()
+	end )
+elseif CLIENT then
+	net.Receive( "sf_concommand_perm_get", function( len )
+		if len == 1 then
+			print( "No such permission: ".. net.ReadString() )
+		else
+			print( net.ReadString(), net.ReadString(), net.ReadString() )
+		end
+	end )
+end
+
+--- Prints the permission passed
+P.registerPrivilege( "permissions.get", "sf_getperm", "Console command to get the required group(s) of a starfall permission" )
+concommand.Add( "sf_getperm", function( ply, _, args )
+	if CLIENT then
+		if not P.privileges[ "permissions.get" ].group[ ply:GetUserGroup() ] then return end
+	end
+
+	if P.privileges[ args[1] ] ~= nil then
+		local perm = P.privileges[ args[1] ]
+		local groups = ""
+		for k, v in pairs( perm.group ) do
+			groups = groups .. k .. " "
+		end
+		if IsValid( ply ) then
+			net.Start( "sf_concommand_perm_get" )
+				net.WriteString( perm.name )
+				net.WriteString( perm.description )
+				net.WriteString( groups )
+			net.Send( ply )
+		else
+			print( perm.name, perm.description, groups )
+		end
+	else
+		if IsValid( ply ) then
+			net.Start( "sf_concommand_perm_get" )
+				net.WriteString( "No such permission: ".. args[ 1 ] or "nil" )
+			net.Send( ply )
+		else
+			print( "No such permission: ".. args[ 1 ] or "nil" )
+		end
+	end
+end )
+
+--- Grants permission ( arg[1] ) to group ( arg[2] )
+P.registerPrivilege( "permissions.add", "sf_addperm", "Console command to grant access to a starfall permission to a usergroup" )
+concommand.Add( "sf_addperm", function( ply, _, args )
+	if CLIENT then
+		if not P.privileges[ "permissions.add" ].group[ ply:GetUserGroup() ] then return end
+	end
+
+	if not P.groups[ args[ 2 ] ] and args[ 2 ] ~= "*" then
+		print( "Invalid group supplied: ".. args[ 2 ] .."." )
+		return
+	end
+
+	if P.privileges[ args[1] ] ~= nil then
+		local perm = P.privileges[ args[1] ]
+		perm.group[ args[2] ] = true
+
+		if SERVER then
+			local queryString = "INSERT INTO ".. P.table .." (`permission`, `group`) SELECT '".. args[ 1 ] .."', '".. args[ 2 ] .."' WHERE NOT EXISTS (SELECT * FROM ".. P.table .." WHERE `group`='".. args[ 1 ] .."' AND `permission`='".. args[ 2 ] .."');"
+
+			if P.useMysqloo and P.database then
+				local query = P.database:query( queryString )
+				query:start()
+			else
+				local query = sql.Query( queryString )
+			end
+		elseif CLIENT then
+			net.Start( "sf_concommand_perm_add" )
+				net.WriteString( id )
+				net.WriteString( group )
+			net.SendToServer()
+		end
+	else
+		print( "No such permission: ".. args[ 1 ] )
+	end
+end )
+
+--- Revokes permission ( arg[1] ) from group ( arg[2] )
+P.registerPrivilege( "permissions.delete", "sf_delperm", "Console command to revoke access to a starfall permission from a usergroup" )
+concommand.Add( "sf_delperm", function( ply, _, args )
+	if CLIENT then
+		if not P.privileges[ "permissions.delete" ].group[ ply:GetUserGroup() ] then return end
+	end
+
+	if not P.groups[ args[ 2 ] ] and args[ 2 ] ~= "*" then
+		print( "Invalid group supplied: ".. args[ 2 ] .."." )
+		return
+	end
+
+	if P.privileges[ args[1] ] ~= nil then
+		local perm = P.privileges[ args[1] ]
+		perm.group[ args[2] ] = nil
+
+		if SERVER then
+			local queryString = "DELETE FROM ".. P.table .." WHERE `permission`='".. args[ 1 ] .."' AND `group`='".. args[ 2 ] .."';"
+
+			if P.useMysqloo and P.database then
+				local query = P.database:query( queryString )
+				query:start()
+			else
+				local query = sql.Query( queryString )
+			end
+		elseif CLIENT then
+			--Request server to delete perm
+		end
+	else
+		print( "No such permission: ".. args[ 1 ] )
+	end
+end )

--- a/lua/starfall/permissions/providers_sv/group.lua
+++ b/lua/starfall/permissions/providers_sv/group.lua
@@ -1,0 +1,82 @@
+---------------------------------------------------------------------
+-- SF Server Group Provider
+---------------------------------------------------------------------
+
+--  TODO: Clients opt-into / out-out-of running client side functions from other users ie. allow clients to run sf_addperm on cl.other perms even without the privilege
+-- TODO: Wildcards for permissions
+-- TODO: A gui for managing permissions / groups
+
+local P = SF.Permissions
+
+if SERVER then --Not needed but just as a safeguard to prevent users from getting mysql information
+	include( "starfall/permissions/database.lua" )
+
+	local queryStr = "CREATE TABLE `".. P.table .."` (`group` text NOT NULL, `permission` varchar(255) NOT NULL);"
+	if P.useMysqloo then
+		require( "mysqloo" )
+
+		if P.host then
+			local function checkTable()
+				local makePermTable = P.database:query( queryStr )
+				makePermTable.onError = function(Q, Err) print("Failed to Create sf permission table: " .. Err) end
+				makePermTable:start()
+				makePermTable:wait()
+			end
+
+			local function connectDB()
+				P.database = mysqloo.connect( P.host, P.user, P.pass, P.dbName, P.port )
+				P.database:connect( )
+
+				function P.database:onConnectionFailed( err )
+					Msg("Starfall permissions database connection error: "..err.."\n")
+				end
+
+				function P.database:onConnected()
+					Msg("Connected to the starfall permissions database\n")
+					checkTable()
+				end
+			end
+			connectDB()
+		end
+	else
+		if not sql.TableExists( P.table ) then
+			local query = sql.Query( queryStr )
+			if query == false then
+				error( "Error creating the SF Permisisons table: ".. sql.LastError() )
+			end
+		end
+	end
+
+	P.groups = {}
+	if evolve then
+		for _, v in pairs( evolve.ranks ) do
+			P.groups[ v.UserGroup ] = true
+		end
+	elseif ulx and ULib then
+		for k, v in pairs( ULib.ucl.groups ) do
+			P.groups[ k ] = true
+		end
+	else
+		P.groups = {
+			[ "superadmin" ] = true,
+			[ "admin" ] = true,
+			[ "user" ] = true
+		}
+	end
+end
+
+local Provider = setmetatable( {}, { __index = SF.Permissions.Provider } )
+
+local ALLOW = SF.Permissions.Result.ALLOW
+local DENY = SF.Permissions.Result.DENY
+local NEUTRAL = SF.Permissions.Result.NEUTRAL
+
+function Provider:check ( principal, target, key )
+	if SF.Permissions.privileges[ key ].group[ principal:GetUserGroup( ) ] or SF.Permissions.privileges[ key ].group[ "*" ] then
+		return ALLOW
+	end
+	SF.throw( "You do not have permission to run ".. SF.Permissions.privileges[ key ].name ..".", 2 )
+	return DENY
+end
+
+SF.Permissions.registerProvider( Provider )

--- a/lua/starfall/permissions/providers_sv/group.lua
+++ b/lua/starfall/permissions/providers_sv/group.lua
@@ -49,8 +49,8 @@ if SERVER then --Not needed but just as a safeguard to prevent users from gettin
 
 	P.groups = {}
 	if evolve then
-		for _, v in pairs( evolve.ranks ) do
-			P.groups[ v.UserGroup ] = true
+		for k, _ in pairs( evolve.ranks ) do
+			P.groups[ k ] = true
 		end
 	elseif ulx and ULib then
 		for k, v in pairs( ULib.ucl.groups ) do
@@ -71,8 +71,16 @@ local ALLOW = SF.Permissions.Result.ALLOW
 local DENY = SF.Permissions.Result.DENY
 local NEUTRAL = SF.Permissions.Result.NEUTRAL
 
+local function getGroup( ply )
+	if evolve then
+		return ply:EV_GetRank( )
+	else
+		return ply:GetUserGroup( )
+	end
+end
+
 function Provider:check ( principal, target, key )
-	if SF.Permissions.privileges[ key ].group[ principal:GetUserGroup( ) ] or SF.Permissions.privileges[ key ].group[ "*" ] then
+	if SF.Permissions.privileges[ key ].group[ getGroup( principal ) ] or SF.Permissions.privileges[ key ].group[ "*" ] then
 		return ALLOW
 	end
 	SF.throw( "You do not have permission to run ".. SF.Permissions.privileges[ key ].name ..".", 2 )


### PR DESCRIPTION
Alright, so I would have loved to do this without modifying core.lua, but some of the things I encountered required me to change it.

Other than that, this is a provider to check a user's group and the privileges associated with them. With this system, all sv and sh privileges are restricted to superadmins by default, which is not a problem in singleplayer. Cl privileges are allowed to all by default for local execution, but when they are checked on clients that are not the owner of the chip, they are denied.
# Core.lua
- Line 25 - 26: removed serverPrivileges as it is no longer of use.
- Line 69 / 67: Changed

``` lua
providers[ provider ] = provider
```

to:

``` lua
providers[ provider ] = true
```

As it is more space efficient.
- Line 114: Added a parameter for the source of the privilege, presently only client calls require the source to be passed. In the future this will allow for handling of privileges based on the source.
- Line 117: Added a hook that is called whenever a new privilege is registered, might be useful for other instances. In this case it was used for the creation of the database elements.
- Line 197 / 198: To expand upon the removal of the serverPrivileges table, while searching through the code for permissions, it was never used in the first place. However, I left the starfall_permissions_privileges in because I was not sure as to what should be done with it as providers_sh/groups.lua does the same thing, but with group included in it.
# database.lua

This is just the configuration file for server administrators that decide to use mysqloo to modify. Even though it is only included on the server, I enclosed it within an if SERVER then to prevent the database information from being acquired maliciously.
# providers_cl/group.lua

I made client permissions have two elements to them, the original ID and a .others ID.

> _Just as a note,it may be better to combine the two privileges into one with two tables within the original ID. One called group which has the rank(s) required to access the privilege and one called groupOthers which has the rank(s) required to run on other clients_
# providers_sh/group.lua

The first half of this file is for handling the initial creation of privileges, and the second half is for the creation of three console commands, _sf_getperm_, _sf_addperm_, and _sf_delperm_, each of which should be pretty self explanitory.
# providers_sv/group.lua

Everything up to line 66 is for the creation of the group perm database, if the user does not opt-into the usage of mysqloo, it will default to the gmod sqlite server. The remainder of the file is for registering the provider, same as in providers_cl/group.lua. 
