### PR TITLE
Changing helper settings to convars

### DIFF
--- a/lua/starfall/sfhelper.lua
+++ b/lua/starfall/sfhelper.lua
@@ -21,21 +21,20 @@ if CLIENT then
 	end
 	helper.getDocs()
 
-	helper.Settings = {}
-	if file.Exists( "sfhelpersettings.txt", "DATA" ) then
-		helper.Settings = util.JSONToTable( file.Read( "sfhelpersettings.txt", "DATA" ) )
-	else
-		helper.Settings.FrameWidth, helper.Settings.FrameHeight = 930, 615
-		helper.Settings.FrameX, helper.Settings.FrameY = ( ScrW() - 930 ) / 2, ( ScrH() - 615 ) / 2
-		helper.Settings.DivHeight = 400
-	end
+	CreateClientConVar( "starfall_helper_wide", 930, true, false )
+	CreateClientConVar( "starfall_helper_tall", 615, true, false )
+	CreateClientConVar( "starfall_helper_posx", ( ScrW() - 930 ) / 2, true, false )
+	CreateClientConVar( "starfall_helper_posy", ( ScrH() - 615 ) / 2, true, false )
+	CreateClientConVar( "starfall_helper_divheight", 400, true, false )
 end
 
 local function saveSettings()
-	helper.Settings.FrameWidth, helper.Settings.FrameHeight = w, h
-	helper.Settings.FrameX, helper.Settings.FrameY = helper.Frame:GetPos()
-	helper.Settings.DivHeight = helper.DocView.Div:GetTopHeight()
-	file.Write( "sfhelpersettings.txt", util.TableToJSON( helper.Settings ) )
+	RunConsoleCommand( "starfall_helper_wide", helper.Frame:GetWide() )
+	RunConsoleCommand( "starfall_helper_tall", helper.Frame:GetTall() )
+	local x, y = helper.Frame:GetPos()
+	RunConsoleCommand( "starfall_helper_posx", x )
+	RunConsoleCommand( "starfall_helper_posy", y )
+	RunConsoleCommand( "starfall_helper_divheight", helper.DocView.Div:GetTopHeight() )
 end
 
 function helper.create()
@@ -656,7 +655,6 @@ function helper.show()
 end
 
 local lastw, lasth = 0, 0
-settings = helper.Settings
 function helper.resize()
 	local w, h = helper.Frame:GetSize()
 
@@ -727,9 +725,9 @@ function helper.resize()
 	helper.AboutView.VBar:SetScroll( helper.AboutView.VBar:GetScroll() )
 
 	if not settings_set then
-		helper.Frame:SetSize( settings.FrameWidth, settings.FrameHeight )
-		helper.Frame:SetPos( settings.FrameX, settings.FrameY )
-		helper.DocView.Div:SetTopHeight( settings.DivHeight )
+		helper.Frame:SetSize( GetConVarNumber( "starfall_helper_wide" ), GetConVarNumber( "starfall_helper_tall" ) )
+		helper.Frame:SetPos( GetConVarNumber( "starfall_helper_posx" ), GetConVarNumber( "starfall_helper_posy" ) )
+		timer.Simple( 0.5, function() helper.DocView.Div:SetTopHeight( GetConVarNumber( "starfall_helper_divheight" ) ) end )
 		settings_set = true
 	end
 

--- a/lua/starfall/sfhelper.lua
+++ b/lua/starfall/sfhelper.lua
@@ -21,20 +21,20 @@ if CLIENT then
 	end
 	helper.getDocs()
 
-	CreateClientConVar( "starfall_helper_wide", 930, true, false )
-	CreateClientConVar( "starfall_helper_tall", 615, true, false )
-	CreateClientConVar( "starfall_helper_posx", ( ScrW() - 930 ) / 2, true, false )
-	CreateClientConVar( "starfall_helper_posy", ( ScrH() - 615 ) / 2, true, false )
-	CreateClientConVar( "starfall_helper_divheight", 400, true, false )
+	CreateClientConVar( "sf_helper_width", 930, true, false )
+	CreateClientConVar( "sf_helper_height", 615, true, false )
+	CreateClientConVar( "sf_helper_posx", ( ScrW() - 930 ) / 2, true, false )
+	CreateClientConVar( "sf_helper_posy", ( ScrH() - 615 ) / 2, true, false )
+	CreateClientConVar( "sf_helper_divheight", 400, true, false )
 end
 
 local function saveSettings()
-	RunConsoleCommand( "starfall_helper_wide", helper.Frame:GetWide() )
-	RunConsoleCommand( "starfall_helper_tall", helper.Frame:GetTall() )
+	RunConsoleCommand( "sf_helper_width", helper.Frame:GetWide() )
+	RunConsoleCommand( "sf_helper_height", helper.Frame:GetTall() )
 	local x, y = helper.Frame:GetPos()
-	RunConsoleCommand( "starfall_helper_posx", x )
-	RunConsoleCommand( "starfall_helper_posy", y )
-	RunConsoleCommand( "starfall_helper_divheight", helper.DocView.Div:GetTopHeight() )
+	RunConsoleCommand( "sf_helper_posx", x )
+	RunConsoleCommand( "sf_helper_posy", y )
+	RunConsoleCommand( "sf_helper_divheight", helper.DocView.Div:GetTopHeight() )
 end
 
 function helper.create()
@@ -725,9 +725,9 @@ function helper.resize()
 	helper.AboutView.VBar:SetScroll( helper.AboutView.VBar:GetScroll() )
 
 	if not settings_set then
-		helper.Frame:SetSize( GetConVarNumber( "starfall_helper_wide" ), GetConVarNumber( "starfall_helper_tall" ) )
-		helper.Frame:SetPos( GetConVarNumber( "starfall_helper_posx" ), GetConVarNumber( "starfall_helper_posy" ) )
-		timer.Simple( 0.5, function() helper.DocView.Div:SetTopHeight( GetConVarNumber( "starfall_helper_divheight" ) ) end )
+		helper.Frame:SetSize( GetConVarNumber( "sf_helper_width" ), GetConVarNumber( "sf_helper_height" ) )
+		helper.Frame:SetPos( GetConVarNumber( "sf_helper_posx" ), GetConVarNumber( "sf_helper_posy" ) )
+		timer.Simple( 0.5, function () helper.DocView.Div:SetTopHeight( GetConVarNumber( "sf_helper_divheight" ) ) end )
 		settings_set = true
 	end
 


### PR DESCRIPTION
I changed the helper settings to be saved as convars as they are more convenient. I also spotted that I made a mistake on the last commit where I 'fixed' the settings being saved. But I was accidentally setting the frame width and height to nil [here](https://github.com/INPStarfall/Starfall/blob/cb7c79debd1e25a492f248d6a86622aa3ba5d855/lua/starfall/sfhelper.lua#L35)
I also fixed the div height not being set properly when the settings are loaded, I simply put it on a timer for 0.5 seconds.
