### PR TITLE
Fixed not throwing an error when using a bad include

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -618,8 +618,8 @@ else
 			net.Start("starfall_upload")
 			net.WriteBit(false)
 			net.SendToServer()
-			if buildlist then
-				SF.AddNotify( "File not found: " .. buildlist, NOTIFY_ERROR, 7, NOTIFYSOUND_ERROR1 )
+			if list then
+				SF.AddNotify( LocalPlayer(), list, NOTIFY_ERROR, 7, NOTIFYSOUND_ERROR1 )
 			end
 		end
 	end)


### PR DESCRIPTION
I removed the "File not found: " because I thought "Bad include: " was self explanatory and it also allows other error messages.

Also its funny because the error checking has never worked, even from when it was implemented. As `buildlist` does not exist. 54744a23a8de0bc8990d95c2860c5cb8f910d071
