### PR TITLE
Move tools to correct wire categories

### DIFF
--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -1,4 +1,4 @@
-TOOL.Category		= "Wire - Control"
+TOOL.Category		= "Chips, Gates"
 TOOL.Name			= "Starfall - Processor"
 TOOL.Command		= nil
 TOOL.ConfigName		= ""

--- a/lua/weapons/gmod_tool/stools/starfall_screen.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_screen.lua
@@ -1,4 +1,5 @@
-TOOL.Category		= "Wire - Display"
+TOOL.Category		= "Visuals/Screens"
+TOOL.Wire_MultiCategories = "Chips, Gates" -- Also add this to the chips, gates category so that it can be found near the processor
 TOOL.Name			= "Starfall - Screen"
 TOOL.Command		= nil
 TOOL.ConfigName		= ""

--- a/lua/weapons/gmod_tool/stools/starfall_screen.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_screen.lua
@@ -1,5 +1,5 @@
 TOOL.Category		= "Visuals/Screens"
-TOOL.Wire_MultiCategories = "Chips, Gates" -- Also add this to the chips, gates category so that it can be found near the processor
+TOOL.Wire_MultiCategories = { "Chips, Gates" } -- Also add this to the chips, gates category so that it can be found near the processor
 TOOL.Name			= "Starfall - Screen"
 TOOL.Command		= nil
 TOOL.ConfigName		= ""


### PR DESCRIPTION
Newest version of wire has rearranged the tool categories a bit. This updates the starfall tools to match
