### PR TITLE
Ownership & CPPI refactor

### DIFF
--- a/lua/entities/starfall_hologram/shared.lua
+++ b/lua/entities/starfall_hologram/shared.lua
@@ -6,11 +6,3 @@ ENT.Author          = "Starfall Organization"
 
 ENT.Spawnable       = false
 ENT.AdminSpawnable  = false
-
-function ENT:HoloSetOwner(ply)
-	self:SetNWEntity("Owner", ply)
-end
-
-function ENT:HoloGetOwner()
-	return self:GetNWEntity("Owner")
-end

--- a/lua/starfall/libs_sv/holograms.lua
+++ b/lua/starfall/libs_sv/holograms.lua
@@ -318,6 +318,22 @@ function holograms_library.create ( pos, ang, model, scale )
             holoent:SetScale( scale )
         end
 
+		-- Lots of ownership stuff
+		-- Old but still supported officially
+		holoent.owner = instance.player
+
+		-- Questionable use cases
+		-- Based on: https://github.com/garrynewman/garrysmod/blob/master/garrysmod/lua/includes/extensions/entity.lua#L53
+		holoent:SetVar( "Player", instance.player )
+		holoent:SetVar( "Owner", instance.player )
+
+		-- Directly set CPPI Owner incase PP doesn't hook onto any of the above.
+		-- As we're not using things such as AddCleanup which is a common 'hook' for PP systems.
+		-- CPPI docs: http://ulyssesmod.net/archive/CPPI_v1-3.pdf
+		if CPPI and holoent.CPPISetOwner then
+			holoent:CPPISetOwner( instance.player )
+		end
+
         local holo = SF.Entities.Wrap( holoent )
 
         holodata.holos[ holo ] = holo

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -600,9 +600,12 @@ if SERVER then
 	--@param ply Player that errored, so we can clear their uploaddata for them to try again. If ply is the err cause, function will skip uploaddata clearing.
 	--@local
 	local function errMaking ( msg, ply )
-		if ply then uploaddata[ ply ] = nil end
+		if ply then
+			uploaddata[ ply ] = nil
+			SF.AddNotify( ply, "[ SPAWN ERROR ] " .. msg, NOTIFY_ERROR, 4, NOTIFYSOUND_ERROR1 )
+		end
+
 		error( msg )
-	
 	end
 
 	--- Creates a SF of the given type.
@@ -618,19 +621,21 @@ if SERVER then
 		-- Sanity checks
 		if not IsValid( ply ) then errMaking( "Invalid player during spawning" ) end
 
-		if type( typ ) ~= "string" or typ == "" or not acceptable_types[ typ ] then
-			errMaking( "Cannot make a Starfall of that type: " .. tostring( typ ) )
+		if type( typ ) ~= "string" or typ == "" then
+			errMaking( "Cannot make a Starfall of that type", ply )
+		elseif not acceptable_types[ typ ] then
+			errMaking( "Cannot make a Starfall of type: " .. typ, ply )
 		end
 
-		if not trace then errMaking( "No trace data for " .. typ .. " specified!" ) end
+		if not trace then errMaking( "No trace data for " .. acceptable_types[ typ ] .. " specified!", ply ) end
 
-		if not model or model == "" then errMaking( "Cannot create a " .. typ .." without a model!" ) end
+		if not model or model == "" then errMaking( "Cannot create a " .. acceptable_types[ typ ] .." without a model!", ply ) end
 
 		-- CheckLimit throws its own error, so just return
 		if not ply:CheckLimit( typ ) then return end
 
 		local sf = ents.Create( typ )
-		if not IsValid( sf ) then errMaking( "Error occurred with creating entity: " .. typ ) end
+		if not IsValid( sf ) then errMaking( "Error occurred with creating entity: " .. acceptable_types[ typ ], ply ) end
 
 		local ang = trace.HitNormal:Angle()
 		ang.pitch = ang.pitch + 90

--- a/lua/weapons/gmod_tool/stools/starfall_screen.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_screen.lua
@@ -83,12 +83,15 @@ function TOOL:LeftClick ( trace )
 
 	if not self:GetSWEP():CheckLimit( "starfall_screen" ) then return false end
 
-	local sf = SF.MakeSF( ply, "starfall_screen", trace, self:GetClientInfo( "Model" ) )
 
 	if not SF.RequestCode( ply, function ( mainfile, files )
 		if not mainfile then return end
+
+		local sf = SF.MakeSF( ply, "starfall_screen", trace, self:GetClientInfo( "Model" ) )
+
 		if not IsValid( sf ) then return end
 		sf:CodeSent( ply, files, mainfile )
+
 	end ) then
 		SF.AddNotify( ply, "Cannot upload SF code, please wait for the current upload to finish.", NOTIFY_ERROR, 7, NOTIFYSOUND_ERROR1 )
 	end

--- a/lua/weapons/gmod_tool/stools/starfall_screen.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_screen.lua
@@ -8,7 +8,6 @@ TOOL.Tab			= "Wire"
 -- ------------------------------- Sending / Recieving ------------------------------- --
 include( "starfall/sflib.lua" )
 
-local MakeSF
 local RequestSend
 
 TOOL.ClientConVar[ "Model" ] = "models/hunter/plates/plate2x2.mdl"
@@ -53,24 +52,6 @@ if SERVER then
 	end
 	
 	CreateConVar( "sbox_maxstarfall_screen", 3, { FCVAR_REPLICATED, FCVAR_NOTIFY, FCVAR_ARCHIVE } )
-	
-	function MakeSF ( pl, Pos, Ang, model)
-		if not pl:CheckLimit( "starfall_screen" ) then return false end
-
-		local sf = ents.Create( "starfall_screen" )
-		if not IsValid( sf ) then return false end
-
-		sf:SetAngles( Ang )
-		sf:SetPos( Pos )
-		sf:SetModel( model )
-		sf:Spawn()
-
-		sf.owner = pl
-
-		pl:AddCount( "starfall_screen", sf )
-
-		return sf
-	end
 else
 	language.Add( "Tool.starfall_screen.name", "Starfall - Screen" )
 	language.Add( "Tool.starfall_screen.desc", "Spawns a starfall screen" )
@@ -100,27 +81,10 @@ function TOOL:LeftClick ( trace )
 	
 	self:SetStage( 0 )
 
-	local model = self:GetClientInfo( "Model" )
 	if not self:GetSWEP():CheckLimit( "starfall_screen" ) then return false end
 
-	local Ang = trace.HitNormal:Angle()
-	Ang.pitch = Ang.pitch + 90
+	local sf = SF.MakeSF( ply, "starfall_screen", trace, self:GetClientInfo( "Model" ) )
 
-	local sf = MakeSF( ply, trace.HitPos, Ang, model )
-
-	local min = sf:OBBMins()
-	sf:SetPos( trace.HitPos - trace.HitNormal * min.z )
-
-	local const = WireLib.Weld( sf, trace.Entity, trace.PhysicsBone, true )
-
-	undo.Create( "Starfall Screen" )
-		undo.AddEntity( sf )
-		undo.AddEntity( const )
-		undo.SetPlayer( ply )
-	undo.Finish()
-
-	ply:AddCleanup( "starfall_screen", sf )
-	
 	if not SF.RequestCode( ply, function ( mainfile, files )
 		if not mainfile then return end
 		if not IsValid( sf ) then return end


### PR DESCRIPTION
Added lots of ownership, 4 methods + CPPI directly to spawning entities and holograms. Took this chance to refactor MakeSF which was duplicated and on the toolguns, pulled it into SF Lib.

Removed some outdated ownership that was never being used from the hologram entity itself.
