### PR TITLE
Resolved globaltables library dependency

### DIFF
--- a/lua/starfall/editor.lua
+++ b/lua/starfall/editor.lua
@@ -47,7 +47,9 @@ local function createCodeMap ()
 		end
 	end
 
-	map.Libraries[ "globaltables" ][ "player" ] = true
+	if map.Libraries[ "globaltables" ] then
+		map.Libraries[ "globaltables" ][ "player" ] = true
+	end
 
 	for k, v in pairs( map.Libraries ) do
 		map.Environment[ k ] = nil


### PR DESCRIPTION
Title, #368 

Only problem is that globaltables is required to be referenced specifically so that the player keyword can be added.
