### PR TITLE
Fixed instance runOnError call

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -280,7 +280,7 @@ end
 function SF.Instance:Error ( msg, traceback )
 	
 	if self.runOnError then -- We have a custom error function, use that instead
-		self.runOnError( msg, traceback )
+		self:runOnError( msg, traceback )
 		return
 	end
 	


### PR DESCRIPTION
as runOnError is defined as function ( instance, ... ), this results in msg being passed as the instance.
