### PR TITLE
Iss373

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -33,10 +33,6 @@ function SF.Instance:runWithOps ( func, ... )
 	local args = { ... }
 	local traceback
 
-	local wrapperfunc = function ()
-		return { func( unpack( args ) ) }
-	end
-
 	local function xpcall_callback ( err )
 		if type( err ) == "table" then
 			if err.message then
@@ -63,6 +59,12 @@ function SF.Instance:runWithOps ( func, ... )
 			debug.sethook( nil )
 			SF.throw( "CPU Quota exceeded.", 0, true )
 		end
+	end
+
+	local wrapperfunc = function ()
+		local ret = { func( unpack( args ) ) }
+		cpuCheck()
+		return ret
 	end
 
 	debug.sethook( cpuCheck, "", 500 )

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -50,10 +50,10 @@ function SF.Instance:runWithOps ( func, ... )
 	local oldSysTime = SysTime()
 
 	local function cpuCheck ()
-		self.cpuTime.current =  SysTime() - oldSysTime
+		self.cpuTime.current = SysTime() - oldSysTime
 
 		local ind = self.cpuTime.bufferI
-		self.cpuTime.buffer[ ind ] = self.cpuTime.current
+		self.cpuTime.buffer[ ind ] = ( self.cpuTime.buffer[ ind ] or 0 ) + self.cpuTime.current
 
 		if self.cpuTime:getBufferAverage() > SF.cpuQuota:GetFloat() then
 			debug.sethook( nil )


### PR DESCRIPTION
cpuTime was only checked every 500 Lua executions of the current execution. The timers described in #373 were executing the Starfall and the execution stopped before the hook fired even once. Due to another bug in the cpuTime checking, the current time spent was reset with every new execution.

This adds a proper check after each execution and fixes that bug.
