### PR TITLE
Fixed Vehicles documentation

### DIFF
--- a/lua/starfall/libs_sh/vehicle.lua
+++ b/lua/starfall/libs_sh/vehicle.lua
@@ -2,6 +2,8 @@
 
 SF.Vehicles = {}
 
+--- Vehicle type for GMod Vehicles<br>
+-- They still behave exactly as <a href='./Entity.html'>Entities</a>, see Entities Type for defined functions
 local vehicle_methods, vehicle_metamethods = SF.Typedef( "Vehicle", SF.Entities.Metatable )
 
 local vwrap = SF.WrapObject
@@ -26,6 +28,8 @@ SF.AddObjectUnwrapper( vehicle_metamethods, unwrap )
 SF.Vehicles.Wrap = wrap
 SF.Vehicles.Unwrap = unwrap
 
+--- toString
+--@shared
 function vehicle_metamethods:__tostring ()
 	local ent = unwrap( self )
 	if not ent then

--- a/lua/starfall/libs_sv/vehicles.lua
+++ b/lua/starfall/libs_sv/vehicles.lua
@@ -1,5 +1,8 @@
 assert( SF.Vehicles )
 
+--- Vehicle type
+--@class class
+--@name Vehicle
 local vehicle_methods = SF.Vehicles.Methods
 local vehicle_metamethods = SF.Vehicles.Metatable
 


### PR DESCRIPTION
Ref #378 

Type wasn't showing up in documentation. Methods also weren't showing after initial Type Def was correctly labelled. Had to add `--@class` tag to the server library for it to register the methods.

The HTML is just a break rank, and a relative hyperlink to the entity library.

Tested out locally using builddocs lua scripts, appeared fine.
