### PR TITLE
hook.runRemote fix w/ cpuTime recursive runWithOps system.

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -7,6 +7,22 @@
 SF.Instance = {}
 SF.Instance.__index = SF.Instance
 
+SF.Instance.sethook = {}
+SF.Instance.sethook.counter = 0
+SF.Instance.sethook.set = function ( func, mask, count )
+	if SF.Instance.sethook.counter == 0 then
+		debug.sethook( func, mask, count )
+	end
+end
+
+SF.Instance.sethook.clear = function ()
+	if SF.Instance.sethook.counter == 0 then
+		debug.sethook( nil )
+	end
+end
+-- Prevent further writing of indexes to this table.
+setmetatable( SF.Instance.sethook, { __newindex = function() return end } )
+
 --- Instance fields
 -- @name Instance
 -- @class table
@@ -67,9 +83,13 @@ function SF.Instance:runWithOps ( func, ... )
 		return ret
 	end
 
-	debug.sethook( cpuCheck, "", 500 )
+	SF.Instance.sethook.set( cpuCheck, "", 500 )
+	SF.Instance.sethook.counter = SF.Instance.sethook.counter + 1
+
 	local ok, rt = xpcall( wrapperfunc, xpcall_callback )
-	debug.sethook( nil )
+
+	SF.Instance.sethook.counter = SF.Instance.sethook.counter - 1
+	SF.Instance.sethook.clear()
 
 	if ok then
 		return true, rt

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -88,7 +88,7 @@ function hook_library.runRemote ( recipient, ... )
 
 		local ok = table.remove( result, 1 )
 		if not ok then
-			if not result[ 1 ] then return end -- Call failed because of non-existent hook. Ignore
+			if not result[ 1 ] then continue end -- Call failed because of non-existent hook. Ignore
 			k:Error( "Hook 'remote' errored with " .. result[ 1 ], result[ 2 ] )
 			-- Their fault - don't return
 		end

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -81,9 +81,10 @@ function hook_library.runRemote ( recipient, ... )
 
 	local instance = SF.instance
 
+	local result = {}
 	for k, _ in pairs( recipients ) do
 		SF.instance = nil
-		local result = { k:runScriptHookForResult( "remote", instance.data.entity, instance.player, ... ) }
+		result = { k:runScriptHookForResult( "remote", instance.data.entity, instance.player, ... ) }
 
 		local ok = table.remove( result, 1 )
 		if not ok then

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -84,7 +84,7 @@ function hook_library.runRemote ( recipient, ... )
 	local result = {}
 	for k, _ in pairs( recipients ) do
 		SF.instance = nil
-		res = { k:runScriptHookForResult( "remote", instance.data.entity, instance.player, ... ) }
+		res = { k:runScriptHookForResult( "remote", SF.WrapObject( instance.data.entity ), SF.WrapObject( instance.player ), ... ) }
 
 		local ok = table.remove( res, 1 )
 		if not ok then

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -84,13 +84,15 @@ function hook_library.runRemote ( recipient, ... )
 	local result = {}
 	for k, _ in pairs( recipients ) do
 		SF.instance = nil
-		result = { k:runScriptHookForResult( "remote", instance.data.entity, instance.player, ... ) }
+		res = { k:runScriptHookForResult( "remote", instance.data.entity, instance.player, ... ) }
 
-		local ok = table.remove( result, 1 )
+		local ok = table.remove( res, 1 )
 		if not ok then
-			if not result[ 1 ] then continue end -- Call failed because of non-existent hook. Ignore
-			k:Error( "Hook 'remote' errored with " .. result[ 1 ], result[ 2 ] )
+			if not res[ 1 ] then continue end -- Call failed because of non-existent hook. Ignore
+			k:Error( "Hook 'remote' errored with " .. res[ 1 ], res[ 2 ] )
 			-- Their fault - don't return
+		else
+			table.insert( result, res )
 		end
 	end
 

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -87,8 +87,9 @@ function hook_library.runRemote ( recipient, ... )
 		res = { k:runScriptHookForResult( "remote", SF.WrapObject( instance.data.entity ), SF.WrapObject( instance.player ), ... ) }
 
 		local ok = table.remove( res, 1 )
+
+		if not res[ 1 ] then continue end -- Call failed because of non-existent hook. Ignore
 		if not ok then
-			if not res[ 1 ] then continue end -- Call failed because of non-existent hook. Ignore
 			k:Error( "Hook 'remote' errored with " .. res[ 1 ], res[ 2 ] )
 			-- Their fault - don't return
 		else


### PR DESCRIPTION
Will Fix #362

runRemote will now return multiple results if multiple remote hooks are defined.
runRemote wrapping issues are now fixed
If an empty result is given ( from a chip not having the hook defined? ), then it is simply ignored.

Return structure from runRemote is now a table of tables. Each first key represents a responding SF chip with a remote hook defined. These then in turn return a table of their results ( as you can return multiple values ). Eg `return 1, "alpha"` would show up as `{ { 1, "alpha", } }`. With a second defined SF remote hook returning something, the results table would look like: `{ { 1, "alpha" }, { 1234 } }`.

Upon fixing runRemote several other bugs came through. Notable that during runRemote we call runWithOps on a remote instance. This would then fail as the sethooks would 'decouple' (?) ( set to nil ), then we'd run away without any ops checking at all!

This is fixed by adding in a simple, global based, counter. As Lua is single threaded and executes all chips sequentially, despite it appearing in parallel. This counter keeps track of the number of 'scopes' / 'recursions' that set hook as gone through and will only remove the sethook when we're in the outermost 'runWithOps' call. Likewise, it will only ever 'set' the hook onto the `wrapperfunc` if we're in the outermost, just for the sake of correctness.

This implements a new table `SF.Instance.sethook`, containing `counter`, the number to track, and 2 functions, `set` and `clear` for setting the `debug.sethook` when counter is only 0.

**NOTE:** If the caller SF chip executes a function defined in a remote hook from the defining SF chip, which contains some form of throw/error. The calling SF will error, but the error message will blame the defining SF chip. This is because the blame level is incorrect; however, the only fix for this would be to malform the traceback in search of some other 'SF' level to blame, which may result in unreliable erroring. This would also have to be global change to how all erroring works. For now, it is not that major a problem.
