### PR TITLE
Fixed entity getColor not returning proper Color structure

### DIFF
--- a/lua/entities/starfall_screen/init.lua
+++ b/lua/entities/starfall_screen/init.lua
@@ -127,8 +127,8 @@ function ENT:CodeSent (ply, files, mainfile)
 		
 		if not self.instance then return end
 		
-		local _, _, _, a = self:GetColor()
-		self:SetColor( Color( 255, 255, 255, a ) )
+		local col = self:GetColor()
+		self:SetColor( Color( 255, 255, 255, col.a ) )
 		self.sharedscreen = true
 	end
 end

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -118,7 +118,8 @@ end
 -- @return Color
 function ents_methods:getColor ()
 	local this = unwrap( self )
-	return this:GetColor()
+	local color = this:GetColor()
+	return SF.Color.Wrap( Color( color.r, color.g, color.b, color.a ) )
 end
 
 --- Checks if an entity is valid.


### PR DESCRIPTION
Engine functions don't return proper color structures, apparently this is intentional.
