### PR TITLE
CPU Cumulative fix

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -75,6 +75,8 @@ function SF.Instance:runWithOps ( func, ... )
 			debug.sethook( nil )
 			SF.throw( "CPU Quota exceeded.", 0, true )
 		end
+
+		oldSysTime = SysTime()
 	end
 
 	local wrapperfunc = function ()

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -66,10 +66,10 @@ function SF.Instance:runWithOps ( func, ... )
 	local oldSysTime = SysTime()
 
 	local function cpuCheck ()
-		self.cpuTime.current = SysTime() - oldSysTime
+		local dt = SysTime() - oldSysTime
 
 		local ind = self.cpuTime.bufferI
-		self.cpuTime.buffer[ ind ] = ( self.cpuTime.buffer[ ind ] or 0 ) + self.cpuTime.current
+		self.cpuTime.buffer[ ind ] = ( self.cpuTime.buffer[ ind ] or 0 ) + dt
 
 		if self.cpuTime:getBufferAverage() > SF.cpuQuota:GetFloat() then
 			debug.sethook( nil )
@@ -131,7 +131,6 @@ function SF.Instance:initialize ()
 	self.cpuTime = {
 		buffer = {},
 		bufferI = 1,
-		current = 0
 	} -- CPU Time Buffer
 
 	local ins = self
@@ -314,7 +313,6 @@ end
 
 --- Updates the buffer index for the CPU Time buffer.
 function SF.Instance:updateCPUBuffer ()
-	self.cpuTime.current = 0
 	self.cpuTime.bufferI = ( self.cpuTime.bufferI % self.context.cpuTime.getBufferN() ) + 1
 	self.cpuTime.buffer[ self.cpuTime.bufferI ] = 0
 end

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -73,7 +73,7 @@ function SF.Instance:runWithOps ( func, ... )
 
 		if self.cpuTime:getBufferAverage() > SF.cpuQuota:GetFloat() then
 			debug.sethook( nil )
-			SF.throw( "CPU Quota exceeded.", 0, true )
+			SF.throw( "CPU Quota Exceeded!", 0, true )
 		end
 
 		oldSysTime = SysTime()

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -114,7 +114,7 @@ SF.DefaultEnvironment.SERVER = SERVER
 -- If used on screens, will show 0 if only rendering is done. Operations must be done in the Think loop for them to be counted.
 -- @return Current quota used this Think
 function SF.DefaultEnvironment.quotaUsed ()
-	return SF.instance.cpuTime.current
+	return SF.instance.cpuTime.buffer[ SF.instance.cpuTime.bufferI ]
 end
 
 --- Gets the Average CPU Time in the buffer


### PR DESCRIPTION
Issue identified by @Jazzelhawk. This was fixed on awilliamson@e432737094f37a26aee4b6a6a633e6b69fd7af0e by implementation of a disposition system. However, this system was untested and may have been too much of a change from the norm.

This cumulative fix is long overdue, and may require tweaking on `sf_timebuffer` lower and `sf_timebuffersize` higher.

If somebody would like to suggest new values, I recommend ~0.003 and 64 respectively. These aren't included in this PR as they are speculative and dependent upon each server, but should be investigated prior to acceptance.
