### PR TITLE
Improved cpuTime quota check by using statistical analysis on cpuTime buffer

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -65,7 +65,7 @@ include( "permissions/core.lua" )
 include( "editor.lua" )
 include( "sfhelper.lua" )
 
-SF.cpuBufferN = CreateConVar( "sf_timebuffersize", 16, { FCVAR_REPLICATED }, "Default number of elements for the CPU Quota Buffer." )
+SF.cpuBufferN = CreateConVar( "sf_timebuffersize", 32, { FCVAR_REPLICATED }, "Default number of elements for the CPU Quota Buffer." )
 
 -- We need to make sure that we clear the table if we shrink it, otherwise leftover values will affect the avg.
 cvars.AddChangeCallback( "sf_timebuffersize", function ( n, o, u )
@@ -77,7 +77,7 @@ cvars.AddChangeCallback( "sf_timebuffersize", function ( n, o, u )
 end )
 
 if SERVER then
-	SF.cpuQuota = CreateConVar( "sf_timebuffer", 0.006, {}, "Default CPU Time Quota for serverside." )
+	SF.cpuQuota = CreateConVar( "sf_timebuffer", 0.0012, {}, "Default CPU Time Quota for serverside." )
 else
 	SF.cpuQuota = CreateClientConVar( "sf_timebuffer", 0.015, false, false )
 end


### PR DESCRIPTION
**EDIT:** I noticed that the analysis alone does not detect large spikes in cpuTime so I changed the quota exceeded expression to include a hard limit on the cpuTime. Together the system is able allow chip cpuTime spikes to exceed the quota limit based on how much much their cpuTime is varying (with more variance allowing the spike to exceed the quota limit more) and is able to catch big spikes with a hard cpuTime limit.
